### PR TITLE
Add setting to disalbe automatic trans fn installation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,17 @@ Installation
     pip install -e git://github.com/clouserw/tower.git#egg=tower
 
 
+Settings
+--------
+
+If you want to provide your own gettext and ngettext functions, set
+``TOWER_INSTALL_JINJA_TRANSLATIONS`` to ``False``, and in your project
+call ``jingo.env.install_gettext_translations`` or
+``jingo.env.install_gettext_callables``. Otherwise tower will ensure its
+gettext and ngettext functions are installed into Jinja2 on every call to
+``tower.activate()``.
+
+
 A note on ``safe``-ness
 -----------------------
 
@@ -41,3 +52,4 @@ be marked as "unsafe" and escaped, unless you use `jingo's
 arguments but not the string they are interpolated into). Like this::
 
     {{ _('Hello <strong>{0}</strong>')|fe(user.nickname) }}
+

--- a/tower/__init__.py
+++ b/tower/__init__.py
@@ -11,6 +11,11 @@ from django.utils.translation import (trans_real as django_trans,
                                       ungettext as django_nugettext)
 
 
+INSTALL_JINJA_TRANSLATIONS = getattr(settings,
+                                     'TOWER_INSTALL_JINJA_TRANSLATIONS',
+                                     True)
+
+
 def ugettext(message, context=None):
     """Always return a stripped string, localized if possible"""
     stripped = strip_whitespace(message)
@@ -65,14 +70,10 @@ def strip_whitespace(message):
     return re.compile(r'\s+', re.UNICODE).sub(' ', message).strip()
 
 
-def activate(locale):
+def install_jinja_translations():
     """
-    Override django's utils.translation.activate().  Django forces files
-    to be named django.mo (http://code.djangoproject.com/ticket/6376).  Since
-    that's dumb and we want to be able to load different files depending on
-    what part of the site the user is in, we'll make our own function here.
+    Install our gettext and ngettext functions into Jinja2's environment.
     """
-
     class Translation(object):
         """
         We pass this object to jinja so it can find our gettext implementation.
@@ -84,6 +85,17 @@ def activate(locale):
 
     import jingo
     jingo.env.install_gettext_translations(Translation)
+
+
+def activate(locale):
+    """
+    Override django's utils.translation.activate().  Django forces files
+    to be named django.mo (http://code.djangoproject.com/ticket/6376).  Since
+    that's dumb and we want to be able to load different files depending on
+    what part of the site the user is in, we'll make our own function here.
+    """
+    if INSTALL_JINJA_TRANSLATIONS:
+        install_jinja_translations()
 
     if django.VERSION >= (1, 3):
         django_trans._active.value = _activate(locale)

--- a/tower/tests/test_l10n.py
+++ b/tower/tests/test_l10n.py
@@ -1,6 +1,3 @@
-import os
-import base64
-import shutil
 from cStringIO import StringIO
 
 import django
@@ -9,14 +6,16 @@ from django.utils import translation
 import jingo
 from jingo.tests.test_helpers import render
 
+from mock import patch
 from nose import with_setup
-from nose.tools import eq_
+from nose.tools import eq_, ok_
 
 import tower
 from tower.tests.helpers import fake_extract_from_dir
 from tower import ugettext as _, ungettext as n_
 from tower import ugettext_lazy as _lazy, ungettext_lazy as n_lazy
 from tower.management.commands.extract import create_pofile_from_babel
+
 
 # Used for the _lazy() tests
 _lazy_strings = {}
@@ -35,11 +34,30 @@ n_lazy_strings['p_context'] = n_lazy('%d poodle please', '%d poodles please',
 def setup():
     tower.activate('xx')
 
+
 def setup_yy():
     tower.activate('yy')
 
+
 def teardown():
     tower.deactivate_all()
+
+
+def test_install_jinja_translations():
+    jingo.env.install_null_translations()
+    tower.activate('xx')
+    eq_(jingo.env.globals['gettext'], _)
+
+
+@patch.object(tower, 'INSTALL_JINJA_TRANSLATIONS', False)
+def test_no_install_jinja_translations():
+    """
+    Setting `TOWER_INSTALL_JINJA_TRANSLATIONS` to False should skip setting
+    the gettext and ngettext functions in the Jinja2 environment.
+    """
+    jingo.env.install_null_translations()
+    tower.activate('xx')
+    ok_(jingo.env.globals['gettext'] != _)
 
 
 @with_setup(setup, teardown)
@@ -188,6 +206,7 @@ def test_template_substitution():
             {{ user }}
             {% endtrans %}'''
     eq_(render(s), 'Hola wenzel')
+
 
 @with_setup(setup, teardown)
 def test_template_substitution_with_pluralization():


### PR DESCRIPTION
This allows users to disable the automatic installation
of gettext and ugettext into Jinja2 on calls to
`tower.activate()`. It also splits out the installation
to its own function so that people may disalbe it in
activate, but still easily set it up when they want.
