### PR TITLE
Revert "Add text template domain"

### DIFF
--- a/tower/management/commands/extract.py
+++ b/tower/management/commands/extract.py
@@ -44,7 +44,7 @@ OPTIONS_MAP = {
 COMMENT_TAGS = ['L10n:']
 
 
-def tweak_message(message, whitespace=False):
+def tweak_message(message):
     """We piggyback on jinja2's babel_extract() (really, Babel's extract_*
     functions) but they don't support some things we need so this function will
     tweak the message.  Specifically:
@@ -55,24 +55,9 @@ def tweak_message(message, whitespace=False):
 
         2) Babel doesn't support context (msgctxt).  We hack that in ourselves
             here.
-
-    :arg message: The message being translated. Either a basestring or
-        tuple.
-    :arg whitespace: Whether or not to keep whitespace.
-
-    :returns: the message
-
     """
-    # If we want to keep the whitespace, we switch strip_whitespace to
-    # the identity function. It's a little weird, but it's either that
-    # or do a bunch of if/else stuff below.
-    if whitespace:
-        _strip_whitespace = lambda x: x
-    else:
-        _strip_whitespace = strip_whitespace
-
     if isinstance(message, basestring):
-        message = _strip_whitespace(message)
+        message = strip_whitespace(message)
     elif isinstance(message, tuple):
         # A tuple of 2 has context, 3 is plural, 4 is plural with context
         if len(message) == 2:
@@ -80,13 +65,13 @@ def tweak_message(message, whitespace=False):
         elif len(message) == 3:
             if all(isinstance(x, basestring) for x in message[:2]):
                 singular, plural, num = message
-                message = (_strip_whitespace(singular),
-                           _strip_whitespace(plural),
+                message = (strip_whitespace(singular),
+                           strip_whitespace(plural),
                            num)
         elif len(message) == 4:
             singular, plural, num, ctxt = message
-            message = (add_context(ctxt, _strip_whitespace(singular)),
-                       add_context(ctxt, _strip_whitespace(plural)),
+            message = (add_context(ctxt, strip_whitespace(singular)),
+                       add_context(ctxt, strip_whitespace(plural)),
                        num)
     return message
 
@@ -105,16 +90,6 @@ def extract_tower_template(fileobj, keywords, comment_tags, options):
             list(ext.babel_extract(fileobj, keywords, comment_tags, options)):
 
         message = tweak_message(message)
-
-        yield lineno, funcname, message, comments
-
-
-def extract_tower_text_template(fileobj, keywords, comment_tags, options):
-    for lineno, funcname, message, comments in \
-            list(ext.babel_extract(fileobj, keywords, comment_tags, options)):
-
-        # Tweak the message, but maintain whitespace
-        message = tweak_message(message, whitespace=True)
 
         yield lineno, funcname, message, comments
 
@@ -171,7 +146,7 @@ class Command(BaseCommand):
                     action='store_true', dest='create', default=False,
                     help='Create output-dir if missing'),
 
-        )
+            )
 
     def handle(self, *args, **options):
         domains = options.get('domain')

--- a/tower/tests/test_l10n.py
+++ b/tower/tests/test_l10n.py
@@ -262,16 +262,6 @@ def test_extract_tower_template():
     eq_(TEST_TEMPLATE_OUTPUT, unicode(create_pofile_from_babel(output)))
 
 
-def test_extract_tower_text_template():
-    fileobj = StringIO(TEST_TEXT_TEMPLATE_INPUT)
-    method = 'tower.management.commands.extract.extract_tower_text_template'
-    output = fake_extract_from_dir(filename="filename", fileobj=fileobj,
-                                   method=method)
-
-    # god help you if these are ever unequal
-    eq_(TEST_TEXT_TEMPLATE_OUTPUT, unicode(create_pofile_from_babel(output)))
-
-
 TEST_PO_INPUT = """
 # Make sure multiple contexts stay separate
 _('fligtar')
@@ -403,84 +393,5 @@ msgstr[1] ""
 #. This string has a hat.
 #: filename:21
 msgid "Let me tell you about a string who spanned multiple lines."
-msgstr ""
-"""
-
-TEST_TEXT_TEMPLATE_INPUT = """
-  {{ _('sunshine') }}
-  {{ _('sunshine', 'nothere') }}
-  {{ _('sunshine', 'outside') }}
-
-  {# Regular comment, regular gettext #}
-  {% trans %}
-    I like pie.
-  {% endtrans %}
-
-  {# L10n: How many hours? #}
-  {% trans plural=4, count=4 %}
-    {{ count }} hour left
-  {% pluralize %}
-    {{ count }} hours left
-  {% endtrans %}
-
-  {{ ngettext("one", "many", 5) }}
-
-  {# L10n: This string has a hat. #}
-  {% trans %}
-  Let me tell you about a string
-  who spanned
-  multiple lines.
-  {% endtrans %}
-"""
-
-TEST_TEXT_TEMPLATE_OUTPUT = """\
-#: filename:2
-msgid "sunshine"
-msgstr ""
-
-#: filename:3
-msgctxt "nothere"
-msgid "sunshine"
-msgstr ""
-
-#: filename:4
-msgctxt "outside"
-msgid "sunshine"
-msgstr ""
-
-#: filename:7
-msgid ""
-"\\n"
-"    I like pie.\\n"
-"  "
-msgstr ""
-
-#. How many hours?
-#: filename:12
-msgid ""
-"\\n"
-"    %(count)s hour left\\n"
-"  "
-msgid_plural ""
-"\\n"
-"    %(count)s hours left\\n"
-"  "
-msgstr[0] ""
-msgstr[1] ""
-
-#: filename:18
-msgid "one"
-msgid_plural "many"
-msgstr[0] ""
-msgstr[1] ""
-
-#. This string has a hat.
-#: filename:21
-msgid ""
-"\\n"
-"  Let me tell you about a string\\n"
-"  who spanned\\n"
-"  multiple lines.\\n"
-"  "
 msgstr ""
 """


### PR DESCRIPTION
This reverts commit 8462172de1a24fa264c5fa542bacfdda711c76dd.

All the text template domain did was cause tower not to collapse
whitespace when extracting strings. However, gettext calls would
collapse whitespace to create the msgid, so then things never
matched and you'd never get localized strings.

I'm reverting this since it doesn't work.

r?
