### PR TITLE
Make translator comment prefix case-insensitive

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for using tower
 Django==1.4.5
-babel
+babel==0.9.6
 jinja2
 translate-toolkit
 -e git://github.com/jbalogh/jingo.git#egg=jingo

--- a/tower/management/commands/extract.py
+++ b/tower/management/commands/extract.py
@@ -43,7 +43,7 @@ OPTIONS_MAP = {
     '**.*': {'extensions': ",".join(JINJA_CONFIG['extensions'])},
 }
 
-COMMENT_TAGS = ['L10n:']
+COMMENT_TAGS = ['L10n:', 'L10N:', 'l10n:', 'l10N:']
 
 
 def create_pounit(filename, lineno, message, comments):

--- a/tower/tests/test_l10n.py
+++ b/tower/tests/test_l10n.py
@@ -294,11 +294,11 @@ ngettext('a fligtar', 'many fligtars', 3, 'aticecreamshop')
 ngettext('a fligtar', 'many fligtars', 5, 'aticecreamshop')
 
 # Test comments
-# L10n: Turn up the volume
+# L10N: Turn up the volume
 _('fligtar    \n\n\r\t  talking')
 
 # Test comments w/ plural and context
-# L10n: Turn down the volume
+# l10n: Turn down the volume
 ngettext('fligtar', 'many fligtars', 5, 'aticecreamshop')
 
 # Test lazy strings are extracted
@@ -335,7 +335,7 @@ msgid_plural "many fligtars"
 msgstr[0] ""
 msgstr[1] ""
 
-#. L10n: Turn down the volume
+#. l10n: Turn down the volume
 #: filename:23
 msgctxt "aticecreamshop"
 msgid "fligtar"
@@ -358,7 +358,7 @@ TEST_TEMPLATE_INPUT = """
     I like pie.
   {% endtrans %}
 
-  {# L10n: How many hours? #}
+  {# l10N: How many hours? #}
   {% trans plural=4, count=4 %}
     {{ count }} hour left
   {% pluralize %}


### PR DESCRIPTION
Translator comments currently must start with exactly "L10n:". Change so that's case-insensitive, e.g. "L10N:" or "l10n:" or "l10N:" also work.

This is for https://bugzilla.mozilla.org/show_bug.cgi?id=868178

(Note: Babel has recently released new versions that break the tower tests. I pinned the Babel version to 0.9.6 rather than trying to fix that in this branch.)
