### PR TITLE
Make Tower extraction compatible with Babel 1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for using tower
 Django==1.4.5
-babel==0.9.6
+babel==1.3
 jinja2
 translate-toolkit
 -e git://github.com/jbalogh/jingo.git#egg=jingo

--- a/tower/management/commands/extract.py
+++ b/tower/management/commands/extract.py
@@ -75,7 +75,14 @@ def create_pofile_from_babel(extracted):
             catalog = po.pofile(inputfile="")
     except AttributeError:
         catalog = po.pofile(inputfile="")
-    for filename, lineno, message, comments in extracted:
+
+    for extracted_unit in extracted:
+        # Babel 1.3 has an additional value: context.
+        if len(extracted_unit) == 5
+            filename, lineno, message, comments, context = extracted_unit
+        else:
+            filename, lineno, message, comments = extracted_unit
+
         unit = create_pounit(filename, lineno, message, comments)
         catalog.addunit(unit)
     catalog.removeduplicates()


### PR DESCRIPTION
Babel 1.3 returns the following tuple: `(filename, lineno, message, comments, context)` (context is new.)
