### PR TITLE
Fix test failures with Babel 1.3, and run tox tests with 1.3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.sw[po]
 pip-log.txt
 .DS_Store
+*.egg-info

--- a/tower/tests/helpers.py
+++ b/tower/tests/helpers.py
@@ -18,8 +18,7 @@ def fake_extract_from_dir(filename, fileobj, method,
     """ We use Babel's exctract_from_dir() to pull out our gettext
     strings.  In the tests, I don't have a directory of files, I have StringIO
     objects.  So, we fake the original function with this one."""
-
-    for lineno, message, comments in extract(method, fileobj, keywords,
+    for lineno, message, comments, context in extract(method, fileobj, keywords,
             comment_tags, options):
 
         yield filename, lineno, message, comments

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ toxworkdir = {homedir}/.tox-tower
 commands =
     python run_tests.py
 deps = -egit+https://github.com/jbalogh/jingo.git#egg=jingo
-    babel==0.9.6
+    babel==1.3
     jinja2
     translate-toolkit
     django-nose


### PR DESCRIPTION
Also adds the .egg-info files to .gitignore. Because why not?