### PR TITLE
Update dependencies. drop python2.6 support, and add django 1.7 and 1.8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 pip-log.txt
 .DS_Store
 *.egg-info
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 matrix:
   include:
    - python: 2.7
-     env: TOXENV=py27-1.5,py27-1.6,py27-1.7
+     env: TOXENV=py27-1.5,py27-1.6,py27-1.7,py27-1.8
 install:
   - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 matrix:
   include:
    - python: 2.7
-     env: TOXENV=py27-1.4,py27-1.5,py27-1.6
+     env: TOXENV=py27-1.5,py27-1.6
 install:
   - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 matrix:
   include:
    - python: 2.7
-     env: TOXENV=py27-1.5,py27-1.6
+     env: TOXENV=py27-1.5,py27-1.6,py27-1.7
 install:
   - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: python
 matrix:
   include:
-   - python: 2.6
-     env:
-       - TOX_ENV=py26-1.4
-       - TOX_ENV=py26-1.5
-       - TOX_ENV=py26-1.6
    - python: 2.7
      env: TOXENV=py27-1.4,py27-1.5,py27-1.6
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: python
-python: 2.6
-env:
-  - TOX_ENV=py26-1.4
-  - TOX_ENV=py26-1.5
-  - TOX_ENV=py26-1.6
-  - TOX_ENV=py27-1.4
-  - TOX_ENV=py27-1.5
-  - TOX_ENV=py27-1.6
+matrix:
+  include:
+   - python: 2.6
+     env:
+       - TOX_ENV=py26-1.4
+       - TOX_ENV=py26-1.5
+       - TOX_ENV=py26-1.6
+   - python: 2.7
+     env: TOXENV=py27-1.4,py27-1.5,py27-1.6
 install:
   - pip install tox
 script:
-  - tox -e $TOX_ENV
+  - tox

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ and the Babel library.
 
 * Author: Wil Clouser and contributors_
 * Licence: BSD
-* Compatibility: Python 2.6 and 2.7, Django 1.4, 1.5 and 1.6
+* Compatibility: Python 2.7, Django 1.4, 1.5 and 1.6
 * Requirements: django, babel, jinja2, jingo and translate-toolkit
 * Project URL: https://github.com/clouserw/tower
 * Documentation: http://tower.readthedocs.org/en/latest/

--- a/examples/tower-project/settings.py
+++ b/examples/tower-project/settings.py
@@ -31,3 +31,12 @@ TOWER_KEYWORDS = {
 }
 
 SECRET_KEY = 'useless not secret key used for tests'
+
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)

--- a/run_tests.py
+++ b/run_tests.py
@@ -18,4 +18,10 @@ setup_test_environment()
 from django.core.management import call_command
 
 # Run the equivalent of "django-admin.py test"
+try:
+    from django import setup
+    setup()
+except ImportError:
+    # Django 1.6 and below does not require setup()
+    pass
 call_command('test')

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]

--- a/tower/tests/test_l10n.py
+++ b/tower/tests/test_l10n.py
@@ -43,10 +43,19 @@ def teardown():
     tower.deactivate_all()
 
 
+def get_jingo_env():
+    try:
+        return jingo.env
+    except Exception:
+        # jingo 0.8 requires get_env() instead.
+        return jingo.get_env()
+
 def test_install_jinja_translations():
-    jingo.env.install_null_translations()
+    env = get_jingo_env()
+
+    env.install_null_translations()
     tower.activate('xx')
-    eq_(jingo.env.globals['gettext'], _)
+    eq_(env.globals['gettext'], _)
 
 
 @patch.object(tower, 'INSTALL_JINJA_TRANSLATIONS', False)
@@ -55,9 +64,11 @@ def test_no_install_jinja_translations():
     Setting `TOWER_INSTALL_JINJA_TRANSLATIONS` to False should skip setting
     the gettext and ngettext functions in the Jinja2 environment.
     """
-    jingo.env.install_null_translations()
+    env = get_jingo_env()
+
+    env.install_null_translations()
     tower.activate('xx')
-    ok_(jingo.env.globals['gettext'] != _)
+    ok_(env.globals['gettext'] != _)
 
 
 @with_setup(setup, teardown)

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@ envlist = py26-1.4, py26-1.5, py26-1.6, py27-1.4, py27-1.5, py27-1.6
 [testenv]
 commands =
     python run_tests.py
-deps = -egit+https://github.com/jbalogh/jingo.git#egg=jingo
+deps = -egit+https://github.com/jbalogh/jingo.git@v0.7.1#egg=jingo
     babel==1.3
     jinja2
     translate-toolkit
-    django-nose
+    django-nose==1.4.3
     mock
 
 [testenv:py26-1.4]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py26-1.4, py26-1.5, py26-1.6, py27-1.4, py27-1.5, py27-1.6
-toxworkdir = {homedir}/.tox-tower
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps = -egit+https://github.com/jbalogh/jingo.git@v0.7.1#egg=jingo
 [testenv:py27-1.4]
 basepython = python2.7
 deps =
-    Django==1.4.10
+    Django==1.4.20
     {[testenv]deps}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-1.4, py27-1.5, py27-1.6
+envlist = py27-1.4, py27-1.5, py27-1.6, py27-1.7
 
 [testenv]
 commands =
@@ -28,4 +28,10 @@ deps =
 basepython = python2.7
 deps =
     Django==1.6
+    {[testenv]deps}
+
+[testenv:py27-1.7]
+basepython = python2.7
+deps =
+    Django==1.7
     {[testenv]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26-1.4, py26-1.5, py26-1.6, py27-1.4, py27-1.5, py27-1.6
+envlist = py27-1.4, py27-1.5, py27-1.6
 
 [testenv]
 commands =
@@ -10,24 +10,6 @@ deps = -egit+https://github.com/jbalogh/jingo.git@v0.7.1#egg=jingo
     translate-toolkit
     django-nose==1.4.3
     mock
-
-[testenv:py26-1.4]
-basepython = python2.6
-deps =
-    Django==1.4.10
-    {[testenv]deps}
-
-[testenv:py26-1.5]
-basepython = python2.6
-deps =
-    Django==1.5.5
-    {[testenv]deps}
-
-[testenv:py26-1.6]
-basepython = python2.6
-deps =
-    Django==1.6
-    {[testenv]deps}
 
 [testenv:py27-1.4]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py27-1.4, py27-1.5, py27-1.6, py27-1.7
+envlist = py27-1.4, py27-1.5, py27-1.6, py27-1.7, py27-1.8
 
 [testenv]
 commands =
     python run_tests.py
-deps = -egit+https://github.com/jbalogh/jingo.git@v0.7.1#egg=jingo
+deps =
     babel==1.3
     jinja2
     translate-toolkit
@@ -15,6 +15,8 @@ deps = -egit+https://github.com/jbalogh/jingo.git@v0.7.1#egg=jingo
 basepython = python2.7
 deps =
     Django==1.4.20
+    -egit+https://github.com/jbalogh/jingo.git@v0.7.1#egg=jingo
+    babel==1.3
     {[testenv]deps}
 
 
@@ -22,16 +24,26 @@ deps =
 basepython = python2.7
 deps =
     Django==1.5.5
+    -egit+https://github.com/jbalogh/jingo.git@v0.7.1#egg=jingo
     {[testenv]deps}
 
 [testenv:py27-1.6]
 basepython = python2.7
 deps =
     Django==1.6
+    -egit+https://github.com/jbalogh/jingo.git@v0.7.1#egg=jingo
     {[testenv]deps}
 
 [testenv:py27-1.7]
 basepython = python2.7
 deps =
-    Django==1.7
+    Django==1.7.11
+    -egit+https://github.com/jbalogh/jingo.git@v0.7.1#egg=jingo
+    {[testenv]deps}
+
+[testenv:py27-1.8]
+basepython = python2.7
+deps =
+    Django==1.8
+    -egit+https://github.com/jbalogh/jingo.git@v0.8.2#egg=jingo
     {[testenv]deps}


### PR DESCRIPTION
 Newer versions of jingo and django-nose no longer work with older
versions of Django, so pin to get tests passing again.